### PR TITLE
Extract symbol and entry price from messages.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T14:30:05.036Z for PR creation at branch issue-1-cd6004def808 for issue https://github.com/Georgepop/Telegram_pars/issues/1

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T14:30:05.036Z for PR creation at branch issue-1-cd6004def808 for issue https://github.com/Georgepop/Telegram_pars/issues/1

--- a/extracted.csv
+++ b/extracted.csv
@@ -1,0 +1,6 @@
+message_id,date,type,symbol,direction,entry_price,has_photo,photo_path
+507024,2026-04-12 14:44:39+00:00,whale_alert,ETH,Long,2188.07,False,
+507022,2026-04-12 14:43:03+00:00,symbol_info,SOL,,81.3300,False,
+507020,2026-04-12 14:39:38+00:00,whale_alert,ETH,Short,2186.95,False,
+507017,2026-04-12 13:59:52+00:00,symbol_info,BTC,,70859.90,False,
+507015,2026-04-12 13:49:04+00:00,symbol_info,SOL,,81.9200,False,

--- a/parse_messages.py
+++ b/parse_messages.py
@@ -1,0 +1,91 @@
+"""
+Parse messages.csv and extract symbol and entry price from:
+- Whale Alert text messages (e.g., "** Long ** **ETH** with **6x** leverage, entry price **$2188.07**")
+- Symbol info messages (e.g., "`Symbol              BTC\nPrice               $70859.90")
+- Photo captions containing the above patterns
+"""
+
+import csv
+import re
+import sys
+
+
+WHALE_ALERT_PATTERN = re.compile(
+    r"\*\*Whale Alert:\*\*.*?"
+    r"\*\*\s*(?P<direction>Long|Short)\s*\*\*\s+\*\*(?P<symbol>[A-Z0-9]+)\*\*"
+    r".*?entry price\s+\*\*\$(?P<entry_price>[\d,]+\.?\d*)\*\*",
+    re.IGNORECASE | re.DOTALL,
+)
+
+SYMBOL_BLOCK_PATTERN = re.compile(
+    r"`Symbol\s+(?P<symbol>[A-Z0-9]+)\s*\n"
+    r"Price\s+\$(?P<price>[\d,]+\.?\d*)",
+    re.IGNORECASE,
+)
+
+
+def extract_whale_alert(text):
+    """Return list of (symbol, direction, entry_price) from Whale Alert messages."""
+    results = []
+    for m in WHALE_ALERT_PATTERN.finditer(text):
+        results.append({
+            "type": "whale_alert",
+            "symbol": m.group("symbol").upper(),
+            "direction": m.group("direction").capitalize(),
+            "entry_price": m.group("entry_price").replace(",", ""),
+        })
+    return results
+
+
+def extract_symbol_block(text):
+    """Return list of (symbol, price) from symbol info blocks."""
+    results = []
+    for m in SYMBOL_BLOCK_PATTERN.finditer(text):
+        results.append({
+            "type": "symbol_info",
+            "symbol": m.group("symbol").upper(),
+            "entry_price": m.group("price").replace(",", ""),
+            "direction": None,
+        })
+    return results
+
+
+def parse_row(row):
+    text = row.get("text", "") or ""
+    results = []
+    results.extend(extract_whale_alert(text))
+    results.extend(extract_symbol_block(text))
+    for r in results:
+        r["message_id"] = row.get("id", "")
+        r["date"] = row.get("date", "")
+        r["has_photo"] = row.get("has_photo", "")
+        r["photo_path"] = row.get("photo_path", "")
+    return results
+
+
+def main(input_path="messages.csv", output_path="extracted.csv"):
+    seen_ids = set()
+    all_results = []
+    with open(input_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            msg_id = row.get("id", "")
+            if msg_id in seen_ids:
+                continue
+            seen_ids.add(msg_id)
+            all_results.extend(parse_row(row))
+
+    fieldnames = ["message_id", "date", "type", "symbol", "direction", "entry_price", "has_photo", "photo_path"]
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(all_results)
+
+    print(f"Extracted {len(all_results)} records to {output_path}")
+    return all_results
+
+
+if __name__ == "__main__":
+    input_path = sys.argv[1] if len(sys.argv) > 1 else "messages.csv"
+    output_path = sys.argv[2] if len(sys.argv) > 2 else "extracted.csv"
+    main(input_path, output_path)

--- a/test_parse_messages.py
+++ b/test_parse_messages.py
@@ -1,0 +1,129 @@
+"""Tests for parse_messages.py"""
+
+import csv
+import io
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from parse_messages import extract_whale_alert, extract_symbol_block, parse_row, main
+
+
+WHALE_LONG_TEXT = (
+    "**Whale Alert:** Hyperliquid Whale **(0x99dd)** ** Long ** **ETH** with **6x** leverage, "
+    "entry price **$2188.07**, position value **$3.01M**. \n\n"
+    "View details on CoinGlass."
+)
+
+WHALE_SHORT_TEXT = (
+    "**Whale Alert:** Hyperliquid Whale **(0xe60d)** ** Short ** **ETH** with **15x** leverage, "
+    "entry price **$2186.95**, position value **$2.08M**. \n\n"
+    "View details on CoinGlass."
+)
+
+SYMBOL_BLOCK_TEXT = (
+    "`Symbol              BTC\n"
+    "Price               $70859.90\n"
+    "Market Cap          $1.42T\n"
+    "`For more details..."
+)
+
+
+def test_extract_whale_alert_long():
+    results = extract_whale_alert(WHALE_LONG_TEXT)
+    assert len(results) == 1
+    r = results[0]
+    assert r["type"] == "whale_alert"
+    assert r["symbol"] == "ETH"
+    assert r["direction"] == "Long"
+    assert r["entry_price"] == "2188.07"
+
+
+def test_extract_whale_alert_short():
+    results = extract_whale_alert(WHALE_SHORT_TEXT)
+    assert len(results) == 1
+    r = results[0]
+    assert r["type"] == "whale_alert"
+    assert r["symbol"] == "ETH"
+    assert r["direction"] == "Short"
+    assert r["entry_price"] == "2186.95"
+
+
+def test_extract_symbol_block():
+    results = extract_symbol_block(SYMBOL_BLOCK_TEXT)
+    assert len(results) == 1
+    r = results[0]
+    assert r["type"] == "symbol_info"
+    assert r["symbol"] == "BTC"
+    assert r["entry_price"] == "70859.90"
+    assert r["direction"] is None
+
+
+def test_extract_whale_alert_no_match():
+    assert extract_whale_alert("Hello world") == []
+
+
+def test_extract_symbol_block_no_match():
+    assert extract_symbol_block("Random text") == []
+
+
+def test_parse_row_whale():
+    row = {
+        "id": "1",
+        "date": "2026-04-12",
+        "text": WHALE_LONG_TEXT,
+        "has_photo": "False",
+        "photo_path": "",
+    }
+    results = parse_row(row)
+    assert len(results) == 1
+    assert results[0]["symbol"] == "ETH"
+    assert results[0]["entry_price"] == "2188.07"
+    assert results[0]["message_id"] == "1"
+
+
+def test_parse_row_symbol_info():
+    row = {
+        "id": "2",
+        "date": "2026-04-12",
+        "text": SYMBOL_BLOCK_TEXT,
+        "has_photo": "False",
+        "photo_path": "",
+    }
+    results = parse_row(row)
+    assert len(results) == 1
+    assert results[0]["symbol"] == "BTC"
+    assert results[0]["entry_price"] == "70859.90"
+
+
+def test_deduplication(tmp_path):
+    csv_content = (
+        "id,date,sender_id,text,has_photo,photo_path,chat_id\n"
+        f'1,2026-04-12,123,"{WHALE_LONG_TEXT}",False,,Chat\n'
+        f'1,2026-04-12,123,"{WHALE_LONG_TEXT}",False,,Chat\n'
+        f'2,2026-04-12,123,"{SYMBOL_BLOCK_TEXT}",False,,Chat\n'
+    )
+    input_file = tmp_path / "test_messages.csv"
+    input_file.write_text(csv_content)
+    output_file = tmp_path / "test_extracted.csv"
+
+    results = main(str(input_file), str(output_file))
+    assert len(results) == 2, f"Expected 2, got {len(results)}: {results}"
+
+
+def test_main_on_real_data():
+    real_csv = os.path.join(os.path.dirname(__file__), "messages.csv")
+    if not os.path.exists(real_csv):
+        pytest.skip("messages.csv not found")
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+        output_path = f.name
+    try:
+        results = main(real_csv, output_path)
+        assert len(results) > 0
+        symbols = {r["symbol"] for r in results}
+        assert "ETH" in symbols or "BTC" in symbols or "SOL" in symbols
+    finally:
+        os.unlink(output_path)


### PR DESCRIPTION
## Summary

Fixes #1

Adds `parse_messages.py` to extract **symbol** and **entry price** from `messages.csv`, handling both message types present in the data:

- **Whale Alert messages** — e.g. `** Long ** **ETH** with **6x** leverage, entry price **$2188.07**` → extracts symbol (`ETH`), direction (`Long`/`Short`), and entry price (`2188.07`)
- **Symbol info blocks** — e.g. `` `Symbol  BTC\nPrice  $70859.90 `` → extracts symbol (`BTC`) and current price as entry price
- **Photo captions** — the same patterns are applied to caption text when photos are present

The script also deduplicates rows (the source CSV contains each message repeated ~25 times) and outputs results to `extracted.csv`.

## How to reproduce the issue

```
python3 parse_messages.py messages.csv extracted.csv
```

Sample output (`extracted.csv`):
```
message_id,date,type,symbol,direction,entry_price,has_photo,photo_path
507024,2026-04-12 14:44:39+00:00,whale_alert,ETH,Long,2188.07,False,
507022,2026-04-12 14:43:03+00:00,symbol_info,SOL,,81.3300,False,
507020,2026-04-12 14:39:38+00:00,whale_alert,ETH,Short,2186.95,False,
507017,2026-04-12 13:59:52+00:00,symbol_info,BTC,,70859.90,False,
507015,2026-04-12 13:49:04+00:00,symbol_info,SOL,,81.9200,False,
```

## Test plan

- [x] `test_extract_whale_alert_long` — parses Long whale alert correctly
- [x] `test_extract_whale_alert_short` — parses Short whale alert correctly
- [x] `test_extract_symbol_block` — parses symbol info block correctly
- [x] `test_parse_row_whale` — full row parsing for whale alert
- [x] `test_parse_row_symbol_info` — full row parsing for symbol info
- [x] `test_deduplication` — duplicate message IDs are processed only once
- [x] `test_main_on_real_data` — runs against the real `messages.csv` and finds expected symbols

Run tests: `python3 -m pytest test_parse_messages.py -v`