### PR TITLE
Extract symbol, entry price, leverage, side from trading photos

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T05:42:57.389Z for PR creation at branch issue-3-c143e76ef2d8 for issue https://github.com/Georgepop/Telegram_pars/issues/3

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T05:42:57.389Z for PR creation at branch issue-3-c143e76ef2d8 for issue https://github.com/Georgepop/Telegram_pars/issues/3

--- a/parse_messages.py
+++ b/parse_messages.py
@@ -1,11 +1,14 @@
 """
-Parse messages.csv and extract symbol and entry price from:
+Parse messages.csv and extract symbol, entry price, leverage, and side from:
 - Whale Alert text messages (e.g., "** Long ** **ETH** with **6x** leverage, entry price **$2188.07**")
 - Symbol info messages (e.g., "`Symbol              BTC\nPrice               $70859.90")
-- Photo captions containing the above patterns
+- Trading position photos (e.g., screenshots showing "SOL LONG 20X", "Entry Price: 85,956")
 """
 
+import base64
 import csv
+import json
+import os
 import re
 import sys
 
@@ -13,7 +16,8 @@ import sys
 WHALE_ALERT_PATTERN = re.compile(
     r"\*\*Whale Alert:\*\*.*?"
     r"\*\*\s*(?P<direction>Long|Short)\s*\*\*\s+\*\*(?P<symbol>[A-Z0-9]+)\*\*"
-    r".*?entry price\s+\*\*\$(?P<entry_price>[\d,]+\.?\d*)\*\*",
+    r".*?with\s+\*\*(?P<leverage>\d+)x\*\*\s+leverage.*?"
+    r"entry price\s+\*\*\$(?P<entry_price>[\d,]+\.?\d*)\*\*",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -23,22 +27,33 @@ SYMBOL_BLOCK_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+_anthropic_client = None
+
+
+def _get_anthropic_client():
+    global _anthropic_client
+    if _anthropic_client is None:
+        import anthropic
+        _anthropic_client = anthropic.Anthropic()
+    return _anthropic_client
+
 
 def extract_whale_alert(text):
-    """Return list of (symbol, direction, entry_price) from Whale Alert messages."""
+    """Return list of dicts from Whale Alert messages."""
     results = []
     for m in WHALE_ALERT_PATTERN.finditer(text):
         results.append({
             "type": "whale_alert",
             "symbol": m.group("symbol").upper(),
             "direction": m.group("direction").capitalize(),
+            "leverage": m.group("leverage"),
             "entry_price": m.group("entry_price").replace(",", ""),
         })
     return results
 
 
 def extract_symbol_block(text):
-    """Return list of (symbol, price) from symbol info blocks."""
+    """Return list of dicts from symbol info blocks."""
     results = []
     for m in SYMBOL_BLOCK_PATTERN.finditer(text):
         results.append({
@@ -46,15 +61,111 @@ def extract_symbol_block(text):
             "symbol": m.group("symbol").upper(),
             "entry_price": m.group("price").replace(",", ""),
             "direction": None,
+            "leverage": None,
         })
     return results
 
 
-def parse_row(row):
+def extract_from_photo(photo_path, base_dir="."):
+    """Extract trading fields from a photo using Claude vision.
+
+    Returns a dict with keys type, symbol, direction, leverage, entry_price,
+    or None if the photo contains no recognizable trading position data.
+    """
+    full_path = os.path.join(base_dir, photo_path) if not os.path.isabs(photo_path) else photo_path
+    if not os.path.exists(full_path):
+        return None
+
+    ext = os.path.splitext(full_path)[1].lower()
+    media_type_map = {".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".webp": "image/webp"}
+    media_type = media_type_map.get(ext, "image/jpeg")
+
+    with open(full_path, "rb") as f:
+        image_data = base64.standard_b64encode(f.read()).decode("utf-8")
+
+    client = _get_anthropic_client()
+    response = client.messages.create(
+        model="claude-haiku-4-5",
+        max_tokens=256,
+        messages=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": image_data,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "This image may be a trading position screenshot. "
+                        "If it shows a trading position with symbol, side (Long/Short), leverage, and/or entry price, "
+                        "extract those fields and respond with JSON only:\n"
+                        '{"symbol": "...", "direction": "Long" or "Short", "leverage": "20" (number only, no X), "entry_price": "85956.00"}\n'
+                        "Use null for any field not visible. Numbers only (no commas, $, or X).\n"
+                        "If the image is NOT a trading position screenshot (e.g. a chart, meme, or unrelated photo), "
+                        'respond with: {"not_trading": true}'
+                    ),
+                },
+            ],
+        }],
+    )
+
+    text = next((b.text for b in response.content if b.type == "text"), "").strip()
+    # Extract JSON from the response
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return None
+
+    try:
+        data = json.loads(match.group())
+    except json.JSONDecodeError:
+        return None
+
+    if data.get("not_trading"):
+        return None
+
+    symbol = data.get("symbol")
+    if not symbol:
+        return None
+
+    # Normalize entry_price: strip commas and currency symbols
+    raw_price = str(data.get("entry_price") or "")
+    entry_price = re.sub(r"[,$]", "", raw_price) or None
+
+    # Normalize leverage: digits only
+    raw_leverage = str(data.get("leverage") or "")
+    leverage = re.sub(r"[^0-9]", "", raw_leverage) or None
+
+    direction = data.get("direction")
+    if direction:
+        direction = direction.capitalize()
+
+    return {
+        "type": "photo",
+        "symbol": symbol.upper(),
+        "direction": direction,
+        "leverage": leverage,
+        "entry_price": entry_price,
+    }
+
+
+def parse_row(row, base_dir=".", use_vision=True):
     text = row.get("text", "") or ""
     results = []
     results.extend(extract_whale_alert(text))
     results.extend(extract_symbol_block(text))
+
+    has_photo = row.get("has_photo", "").strip().lower() == "true"
+    photo_path = row.get("photo_path", "").strip()
+    if use_vision and has_photo and photo_path:
+        photo_result = extract_from_photo(photo_path, base_dir=base_dir)
+        if photo_result:
+            results.append(photo_result)
+
     for r in results:
         r["message_id"] = row.get("id", "")
         r["date"] = row.get("date", "")
@@ -63,7 +174,8 @@ def parse_row(row):
     return results
 
 
-def main(input_path="messages.csv", output_path="extracted.csv"):
+def main(input_path="messages.csv", output_path="extracted.csv", use_vision=True):
+    base_dir = os.path.dirname(os.path.abspath(input_path))
     seen_ids = set()
     all_results = []
     with open(input_path, newline="", encoding="utf-8") as f:
@@ -73,9 +185,9 @@ def main(input_path="messages.csv", output_path="extracted.csv"):
             if msg_id in seen_ids:
                 continue
             seen_ids.add(msg_id)
-            all_results.extend(parse_row(row))
+            all_results.extend(parse_row(row, base_dir=base_dir, use_vision=use_vision))
 
-    fieldnames = ["message_id", "date", "type", "symbol", "direction", "entry_price", "has_photo", "photo_path"]
+    fieldnames = ["message_id", "date", "type", "symbol", "direction", "leverage", "entry_price", "has_photo", "photo_path"]
     with open(output_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()

--- a/test_parse_messages.py
+++ b/test_parse_messages.py
@@ -5,9 +5,10 @@ import io
 import sys
 import os
 import pytest
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(__file__))
-from parse_messages import extract_whale_alert, extract_symbol_block, parse_row, main
+from parse_messages import extract_whale_alert, extract_symbol_block, extract_from_photo, parse_row, main
 
 
 WHALE_LONG_TEXT = (
@@ -29,6 +30,14 @@ SYMBOL_BLOCK_TEXT = (
     "`For more details..."
 )
 
+DOWNLOADS_DIR = os.path.join(os.path.dirname(__file__), "downloads")
+PHOTO_SOL = os.path.join(DOWNLOADS_DIR, "INVEST ZONE Chat 💬_20260426_045028.jpg")
+PHOTO_TRUMP = os.path.join(DOWNLOADS_DIR, "INVEST ZONE Chat 💬_20260426_053249.jpg")
+PHOTO_BTC = os.path.join(DOWNLOADS_DIR, "INVEST ZONE Chat 💬_20260426_053335.jpg")
+PHOTO_ETH = os.path.join(DOWNLOADS_DIR, "INVEST ZONE Chat 💬_20260426_053403.jpg")
+PHOTO_CHART = os.path.join(DOWNLOADS_DIR, "INVEST ZONE Chat 💬_20260426_053504.jpg")
+PHOTO_UNRELATED = os.path.join(DOWNLOADS_DIR, "INVEST ZONE Chat 💬_20260426_053358.jpg")
+
 
 def test_extract_whale_alert_long():
     results = extract_whale_alert(WHALE_LONG_TEXT)
@@ -37,6 +46,7 @@ def test_extract_whale_alert_long():
     assert r["type"] == "whale_alert"
     assert r["symbol"] == "ETH"
     assert r["direction"] == "Long"
+    assert r["leverage"] == "6"
     assert r["entry_price"] == "2188.07"
 
 
@@ -47,6 +57,7 @@ def test_extract_whale_alert_short():
     assert r["type"] == "whale_alert"
     assert r["symbol"] == "ETH"
     assert r["direction"] == "Short"
+    assert r["leverage"] == "15"
     assert r["entry_price"] == "2186.95"
 
 
@@ -58,6 +69,7 @@ def test_extract_symbol_block():
     assert r["symbol"] == "BTC"
     assert r["entry_price"] == "70859.90"
     assert r["direction"] is None
+    assert r["leverage"] is None
 
 
 def test_extract_whale_alert_no_match():
@@ -76,9 +88,10 @@ def test_parse_row_whale():
         "has_photo": "False",
         "photo_path": "",
     }
-    results = parse_row(row)
+    results = parse_row(row, use_vision=False)
     assert len(results) == 1
     assert results[0]["symbol"] == "ETH"
+    assert results[0]["leverage"] == "6"
     assert results[0]["entry_price"] == "2188.07"
     assert results[0]["message_id"] == "1"
 
@@ -91,7 +104,7 @@ def test_parse_row_symbol_info():
         "has_photo": "False",
         "photo_path": "",
     }
-    results = parse_row(row)
+    results = parse_row(row, use_vision=False)
     assert len(results) == 1
     assert results[0]["symbol"] == "BTC"
     assert results[0]["entry_price"] == "70859.90"
@@ -108,7 +121,7 @@ def test_deduplication(tmp_path):
     input_file.write_text(csv_content)
     output_file = tmp_path / "test_extracted.csv"
 
-    results = main(str(input_file), str(output_file))
+    results = main(str(input_file), str(output_file), use_vision=False)
     assert len(results) == 2, f"Expected 2, got {len(results)}: {results}"
 
 
@@ -121,9 +134,145 @@ def test_main_on_real_data():
     with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
         output_path = f.name
     try:
-        results = main(real_csv, output_path)
+        results = main(real_csv, output_path, use_vision=False)
         assert len(results) > 0
         symbols = {r["symbol"] for r in results}
         assert "ETH" in symbols or "BTC" in symbols or "SOL" in symbols
     finally:
         os.unlink(output_path)
+
+
+# --- Photo extraction tests ---
+
+def _make_photo_api_response(symbol, direction, leverage, entry_price):
+    """Build a mock Anthropic API response for photo extraction."""
+    import json
+    payload = {"symbol": symbol, "direction": direction, "leverage": leverage, "entry_price": entry_price}
+    mock_block = MagicMock()
+    mock_block.type = "text"
+    mock_block.text = json.dumps(payload)
+    mock_response = MagicMock()
+    mock_response.content = [mock_block]
+    return mock_response
+
+
+def _make_not_trading_response():
+    mock_block = MagicMock()
+    mock_block.type = "text"
+    mock_block.text = '{"not_trading": true}'
+    mock_response = MagicMock()
+    mock_response.content = [mock_block]
+    return mock_response
+
+
+@pytest.mark.skipif(not os.path.exists(PHOTO_SOL), reason="SOL photo not available")
+def test_extract_from_photo_sol_with_mock():
+    mock_response = _make_photo_api_response("SOL", "Long", "20", "85956")
+    with patch("parse_messages._get_anthropic_client") as mock_client_fn:
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        mock_client_fn.return_value = mock_client
+        result = extract_from_photo(PHOTO_SOL)
+
+    assert result is not None
+    assert result["symbol"] == "SOL"
+    assert result["direction"] == "Long"
+    assert result["leverage"] == "20"
+    assert result["entry_price"] == "85956"
+    assert result["type"] == "photo"
+
+
+@pytest.mark.skipif(not os.path.exists(PHOTO_TRUMP), reason="TRUMP photo not available")
+def test_extract_from_photo_trump_with_mock():
+    mock_response = _make_photo_api_response("TRUMPUSDT", "Long", "75", None)
+    with patch("parse_messages._get_anthropic_client") as mock_client_fn:
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        mock_client_fn.return_value = mock_client
+        result = extract_from_photo(PHOTO_TRUMP)
+
+    assert result is not None
+    assert result["symbol"] == "TRUMPUSDT"
+    assert result["direction"] == "Long"
+    assert result["leverage"] == "75"
+
+
+@pytest.mark.skipif(not os.path.exists(PHOTO_CHART), reason="Chart photo not available")
+def test_extract_from_photo_not_trading_returns_none():
+    with patch("parse_messages._get_anthropic_client") as mock_client_fn:
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = _make_not_trading_response()
+        mock_client_fn.return_value = mock_client
+        result = extract_from_photo(PHOTO_CHART)
+
+    assert result is None
+
+
+def test_extract_from_photo_missing_file():
+    result = extract_from_photo("/nonexistent/path/photo.jpg")
+    assert result is None
+
+
+def test_parse_row_with_photo_vision(tmp_path):
+    """parse_row calls extract_from_photo when has_photo=True."""
+    fake_photo = tmp_path / "test.jpg"
+    fake_photo.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+    mock_response = _make_photo_api_response("BTC", "Long", "100", "97800")
+    with patch("parse_messages._get_anthropic_client") as mock_client_fn:
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        mock_client_fn.return_value = mock_client
+
+        row = {
+            "id": "99",
+            "date": "2026-04-26",
+            "text": "",
+            "has_photo": "True",
+            "photo_path": str(fake_photo),
+        }
+        results = parse_row(row, base_dir="", use_vision=True)
+
+    photo_results = [r for r in results if r["type"] == "photo"]
+    assert len(photo_results) == 1
+    r = photo_results[0]
+    assert r["symbol"] == "BTC"
+    assert r["direction"] == "Long"
+    assert r["leverage"] == "100"
+    assert r["entry_price"] == "97800"
+    assert r["message_id"] == "99"
+
+
+@pytest.mark.skipif(
+    not os.path.exists(PHOTO_SOL),
+    reason="Sample photos not available for live API test",
+)
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set — skipping live API test",
+)
+def test_extract_from_photo_sol_live():
+    """Live API test: extract trading fields from the SOL position photo."""
+    result = extract_from_photo(PHOTO_SOL)
+    assert result is not None, "Expected trading data from SOL position photo"
+    assert result["symbol"] in ("SOL", "SOLUSDT", "SOL/USDT")
+    assert result["direction"] in ("Long", "Short")
+    assert result["leverage"] is not None
+    assert result["entry_price"] is not None
+
+
+@pytest.mark.skipif(
+    not os.path.exists(PHOTO_BTC),
+    reason="Sample photos not available for live API test",
+)
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set — skipping live API test",
+)
+def test_extract_from_photo_btc_live():
+    """Live API test: extract trading fields from the BTCUSDT position photo."""
+    result = extract_from_photo(PHOTO_BTC)
+    assert result is not None
+    assert "BTC" in result["symbol"]
+    assert result["direction"] == "Long"
+    assert result["leverage"] == "100"


### PR DESCRIPTION
## Summary

Implements [issue #3](https://github.com/Georgepop/Telegram_pars/issues/3): extract **symbol**, **entry price**, **leverage**, and **side (Long/Short)** from trading position photos in the `downloads/` folder.

### How to reproduce the issue

The original `parse_messages.py` only parsed text messages and ignored photos. Messages with `has_photo=True` that contain trading position screenshots (e.g. "SOL LONG 20X", "Entry Price: 85,956") produced no output.

### What was changed

**`parse_messages.py`**
- Added `extract_from_photo(photo_path)`: sends a trading screenshot to Claude vision API (`claude-haiku-4-5`) and returns structured data — `symbol`, `direction`, `leverage`, `entry_price` — or `None` for non-trading images (charts, memes, etc.)
- `parse_row()`: now calls `extract_from_photo` when `has_photo=True`; controlled by `use_vision=True` flag (default) so tests can skip API calls
- `main()`: threads `base_dir` through so photo paths resolve correctly relative to the CSV location; adds `leverage` column to output CSV
- `extract_whale_alert()`: now also captures **leverage** from Whale Alert text messages

**`test_parse_messages.py`**
- Mock-based unit tests for all photo extraction paths: trading photo → dict, non-trading photo → None, missing file → None, parse_row with photo
- Updated text extraction tests to assert on the new `leverage` field
- Two optional live API tests (skipped when `ANTHROPIC_API_KEY` is absent)

### Extracted fields

| Field | Source | Example |
|---|---|---|
| `symbol` | photo or text | `SOL`, `BTCUSDT`, `ETH` |
| `direction` | photo or text | `Long`, `Short` |
| `leverage` | photo or text | `20`, `100`, `15` |
| `entry_price` | photo or text | `85956`, `2188.07` |

### Test results

```
14 passed, 2 skipped
```

All 14 mock-based tests pass. The 2 live API tests are skipped when `ANTHROPIC_API_KEY` is not set.

### Requirements

```
pip install anthropic
```
`ANTHROPIC_API_KEY` must be set in the environment for photo extraction to work at runtime.


Fixes Georgepop/Telegram_pars#3