### PR TITLE
Extract trading signals from photos via Anthropic API (ANTHROPIC_API_KEY from env)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T06:32:29.786Z for PR creation at branch issue-5-c5069951f22b for issue https://github.com/Georgepop/Telegram_pars/issues/5

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T06:32:29.786Z for PR creation at branch issue-5-c5069951f22b for issue https://github.com/Georgepop/Telegram_pars/issues/5

--- a/parse_messages.py
+++ b/parse_messages.py
@@ -3,9 +3,12 @@ Parse messages.csv and extract symbol and entry price from:
 - Whale Alert text messages (e.g., "** Long ** **ETH** with **6x** leverage, entry price **$2188.07**")
 - Symbol info messages (e.g., "`Symbol              BTC\nPrice               $70859.90")
 - Photo captions containing the above patterns
+- Photos analyzed via the Anthropic API (Claude vision) when ANTHROPIC_API_KEY is available
 """
 
+import base64
 import csv
+import os
 import re
 import sys
 
@@ -22,6 +25,20 @@ SYMBOL_BLOCK_PATTERN = re.compile(
     r"Price\s+\$(?P<price>[\d,]+\.?\d*)",
     re.IGNORECASE,
 )
+
+_anthropic_client = None
+
+
+def _get_anthropic_client():
+    """Return a cached Anthropic client, initialised from ANTHROPIC_API_KEY env var."""
+    global _anthropic_client
+    if _anthropic_client is None:
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            return None
+        import anthropic
+        _anthropic_client = anthropic.Anthropic(api_key=api_key)
+    return _anthropic_client
 
 
 def extract_whale_alert(text):
@@ -50,11 +67,81 @@ def extract_symbol_block(text):
     return results
 
 
+def extract_from_photo(photo_path):
+    """Use Claude vision to extract trading signal data from a photo.
+
+    Returns a list with one dict if a trading signal is found, otherwise [].
+    Requires ANTHROPIC_API_KEY to be set; returns [] silently when it is not.
+    """
+    client = _get_anthropic_client()
+    if not client:
+        return []
+    if not photo_path or not os.path.exists(photo_path):
+        return []
+
+    with open(photo_path, "rb") as f:
+        image_data = base64.standard_b64encode(f.read()).decode("utf-8")
+
+    ext = os.path.splitext(photo_path)[1].lower()
+    media_type_map = {".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".webp": "image/webp"}
+    media_type = media_type_map.get(ext, "image/jpeg")
+
+    prompt = (
+        "This image may contain a cryptocurrency trading signal. "
+        "If it does, extract the following fields and reply with ONLY a single line in this exact format:\n"
+        "SYMBOL=<symbol> DIRECTION=<Long|Short> ENTRY_PRICE=<number>\n"
+        "Use the base symbol without USDT/USD suffix (e.g. BTC not BTCUSDT). "
+        "If the image does not contain a clear trading signal with an entry price, reply with: NO_SIGNAL"
+    )
+
+    message = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=64,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "base64", "media_type": media_type, "data": image_data}},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    )
+
+    reply = message.content[0].text.strip()
+    if reply == "NO_SIGNAL" or not reply.startswith("SYMBOL="):
+        return []
+
+    parsed = {}
+    for token in reply.split():
+        if "=" in token:
+            k, _, v = token.partition("=")
+            parsed[k] = v
+
+    symbol = parsed.get("SYMBOL", "").upper()
+    direction = parsed.get("DIRECTION", "").capitalize()
+    entry_price = parsed.get("ENTRY_PRICE", "").replace(",", "")
+
+    if not symbol or not entry_price:
+        return []
+
+    return [{
+        "type": "photo_signal",
+        "symbol": symbol,
+        "direction": direction if direction in ("Long", "Short") else None,
+        "entry_price": entry_price,
+    }]
+
+
 def parse_row(row):
     text = row.get("text", "") or ""
     results = []
     results.extend(extract_whale_alert(text))
     results.extend(extract_symbol_block(text))
+
+    if not results and row.get("has_photo", "").lower() == "true":
+        results.extend(extract_from_photo(row.get("photo_path", "") or ""))
+
     for r in results:
         r["message_id"] = row.get("id", "")
         r["date"] = row.get("date", "")

--- a/test_parse_messages.py
+++ b/test_parse_messages.py
@@ -4,10 +4,11 @@ import csv
 import io
 import sys
 import os
+from unittest.mock import MagicMock, patch
 import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
-from parse_messages import extract_whale_alert, extract_symbol_block, parse_row, main
+from parse_messages import extract_whale_alert, extract_symbol_block, extract_from_photo, parse_row, main
 
 
 WHALE_LONG_TEXT = (
@@ -110,6 +111,134 @@ def test_deduplication(tmp_path):
 
     results = main(str(input_file), str(output_file))
     assert len(results) == 2, f"Expected 2, got {len(results)}: {results}"
+
+
+def _make_anthropic_response(text):
+    """Build a minimal mock Anthropic response object."""
+    content_block = MagicMock()
+    content_block.text = text
+    response = MagicMock()
+    response.content = [content_block]
+    return response
+
+
+def test_extract_from_photo_no_key(tmp_path):
+    """Returns [] when ANTHROPIC_API_KEY is not set."""
+    img = tmp_path / "signal.jpg"
+    img.write_bytes(b"\xff\xd8\xff")  # minimal JPEG header
+    import parse_messages
+    parse_messages._anthropic_client = None
+    with patch.dict(os.environ, {}, clear=True):
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        result = extract_from_photo(str(img))
+    assert result == []
+
+
+def test_extract_from_photo_missing_file():
+    """Returns [] when photo path does not exist."""
+    with patch("parse_messages._get_anthropic_client") as mock_client:
+        mock_client.return_value = MagicMock()
+        result = extract_from_photo("/nonexistent/path.jpg")
+    assert result == []
+
+
+def test_extract_from_photo_no_signal(tmp_path):
+    """Returns [] when Claude says NO_SIGNAL."""
+    img = tmp_path / "chart.jpg"
+    img.write_bytes(b"\xff\xd8\xff")
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_anthropic_response("NO_SIGNAL")
+
+    with patch("parse_messages._get_anthropic_client", return_value=mock_client):
+        result = extract_from_photo(str(img))
+
+    assert result == []
+
+
+def test_extract_from_photo_long_signal(tmp_path):
+    """Parses a Long trading signal from Claude's response."""
+    img = tmp_path / "sol_long.jpg"
+    img.write_bytes(b"\xff\xd8\xff")
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_anthropic_response(
+        "SYMBOL=SOL DIRECTION=Long ENTRY_PRICE=85956"
+    )
+
+    with patch("parse_messages._get_anthropic_client", return_value=mock_client):
+        result = extract_from_photo(str(img))
+
+    assert len(result) == 1
+    r = result[0]
+    assert r["type"] == "photo_signal"
+    assert r["symbol"] == "SOL"
+    assert r["direction"] == "Long"
+    assert r["entry_price"] == "85956"
+
+
+def test_extract_from_photo_short_signal(tmp_path):
+    """Parses a Short trading signal from Claude's response."""
+    img = tmp_path / "btc_short.jpg"
+    img.write_bytes(b"\xff\xd8\xff")
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_anthropic_response(
+        "SYMBOL=BTC DIRECTION=Short ENTRY_PRICE=77500.50"
+    )
+
+    with patch("parse_messages._get_anthropic_client", return_value=mock_client):
+        result = extract_from_photo(str(img))
+
+    assert len(result) == 1
+    assert result[0]["symbol"] == "BTC"
+    assert result[0]["direction"] == "Short"
+    assert result[0]["entry_price"] == "77500.50"
+
+
+def test_parse_row_falls_back_to_photo(tmp_path):
+    """parse_row calls extract_from_photo when has_photo=True and no text match."""
+    img = tmp_path / "signal.jpg"
+    img.write_bytes(b"\xff\xd8\xff")
+
+    row = {
+        "id": "42",
+        "date": "2026-04-26",
+        "text": "",
+        "has_photo": "True",
+        "photo_path": str(img),
+    }
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_anthropic_response(
+        "SYMBOL=ETH DIRECTION=Long ENTRY_PRICE=2500.00"
+    )
+
+    with patch("parse_messages._get_anthropic_client", return_value=mock_client):
+        results = parse_row(row)
+
+    assert len(results) == 1
+    assert results[0]["symbol"] == "ETH"
+    assert results[0]["message_id"] == "42"
+    assert results[0]["type"] == "photo_signal"
+
+
+def test_parse_row_skips_photo_when_text_matched():
+    """parse_row does NOT call extract_from_photo when text already matched."""
+    row = {
+        "id": "99",
+        "date": "2026-04-26",
+        "text": WHALE_LONG_TEXT,
+        "has_photo": "True",
+        "photo_path": "/some/image.jpg",
+    }
+
+    with patch("parse_messages.extract_from_photo") as mock_photo:
+        results = parse_row(row)
+
+    mock_photo.assert_not_called()
+    assert len(results) == 1
+    assert results[0]["symbol"] == "ETH"
 
 
 def test_main_on_real_data():


### PR DESCRIPTION
## Summary

Fixes Georgepop/Telegram_pars#5

Adds Claude vision-based extraction of trading signals from photos using the Anthropic API. The `ANTHROPIC_API_KEY` is read from the server environment — never hardcoded.

### What changed

- **`parse_messages.py`** — new `extract_from_photo(photo_path)` function:
  - Reads `ANTHROPIC_API_KEY` from the environment via `os.environ.get("ANTHROPIC_API_KEY")`
  - Encodes the image as base64 and sends it to `claude-haiku-4-5-20251001` with a structured prompt
  - Returns `[{type, symbol, direction, entry_price}]` when a signal is found, `[]` otherwise
  - Gracefully returns `[]` when the key is absent or the file does not exist
- **`parse_row()`** — falls back to `extract_from_photo()` only when `has_photo=True` and no text pattern matched (avoids unnecessary API calls)
- **`test_parse_messages.py`** — 7 new tests covering all branches with mocked Anthropic responses

### How to reproduce the original problem

Photos in the Telegram channel (e.g. `downloads/INVEST ZONE Chat 💬_20260426_045028.jpg`) contain trading signals like:

```
SOL  LONG 20X
Entry Price  85,956
```

These were invisible to regex-only parsing. With this change, set `ANTHROPIC_API_KEY` and re-run:

```bash
export ANTHROPIC_API_KEY=sk-ant-...
python3 parse_messages.py messages.csv extracted.csv
```

### Test plan

- [x] `test_extract_from_photo_no_key` — returns `[]` when env var absent (no API call)
- [x] `test_extract_from_photo_missing_file` — returns `[]` for non-existent path
- [x] `test_extract_from_photo_no_signal` — returns `[]` when Claude replies `NO_SIGNAL`
- [x] `test_extract_from_photo_long_signal` — parses Long signal correctly
- [x] `test_extract_from_photo_short_signal` — parses Short signal correctly
- [x] `test_parse_row_falls_back_to_photo` — `parse_row` invokes photo extraction for photo-only rows
- [x] `test_parse_row_skips_photo_when_text_matched` — photo extraction is skipped when text already matched
- [x] All 9 original tests continue to pass

Run: `python3 -m pytest test_parse_messages.py -v`