### PR TITLE
Add check_usdt_pair: identify which USDT pair a message refers to

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-27T10:03:56.440Z for PR creation at branch issue-7-d4d78977dfab for issue https://github.com/Georgepop/Telegram_pars/issues/7

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-27T10:03:56.440Z for PR creation at branch issue-7-d4d78977dfab for issue https://github.com/Georgepop/Telegram_pars/issues/7

--- a/parse_messages.py
+++ b/parse_messages.py
@@ -12,6 +12,38 @@ import os
 import re
 import sys
 
+import requests
+
+_usdt_symbols = None
+
+
+def _load_usdt_symbols():
+    """Fetch and cache all active USDT perpetual symbols from Binance."""
+    global _usdt_symbols
+    if _usdt_symbols is None:
+        try:
+            data = requests.get('https://fapi.binance.com/fapi/v1/exchangeInfo', timeout=10).json()
+            raw = [x["symbol"] for x in data["symbols"] if x['status'] == 'TRADING']
+            _usdt_symbols = sorted([i.upper() for i in raw if i.upper().endswith('USDT')])
+        except Exception:
+            _usdt_symbols = []
+    return _usdt_symbols
+
+
+def check_usdt_pair(text):
+    """Return the most specific USDT pair symbol mentioned in *text*, or None.
+
+    Fetches the active Binance USDT perpetual symbol list on first call and
+    caches it for subsequent calls.  When multiple symbols match, the one with
+    the longest base token (e.g. TRUMPUSDT over BTCUSDT when both bases appear)
+    is returned so that compound ticker names are preferred over short ones.
+    """
+    symbols = _load_usdt_symbols()
+    matched = [s for s in symbols if s[:-4] in str(text).upper()]
+    if not matched:
+        return None
+    return max(matched, key=lambda s: len(s))
+
 
 WHALE_ALERT_PATTERN = re.compile(
     r"\*\*Whale Alert:\*\*.*?"

--- a/test_parse_messages.py
+++ b/test_parse_messages.py
@@ -4,6 +4,7 @@ import csv
 import io
 import sys
 import os
+import runpy
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -283,6 +284,19 @@ def test_extract_from_photo_btc_live():
 _FAKE_SYMBOLS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "TRUMPUSDT", "XRPUSDT"]
 
 
+def _fake_exchange_info(symbols):
+    class FakeResponse:
+        def json(self):
+            return {
+                "symbols": [
+                    {"symbol": symbol, "status": "TRADING"}
+                    for symbol in symbols
+                ]
+            }
+
+    return FakeResponse()
+
+
 def test_check_usdt_pair_btc(monkeypatch):
     monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
     assert check_usdt_pair("BTC is pumping today") == "BTCUSDT"
@@ -317,3 +331,28 @@ def test_check_usdt_pair_case_insensitive(monkeypatch):
 def test_check_usdt_pair_empty_string(monkeypatch):
     monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
     assert check_usdt_pair("") is None
+
+
+def test_usdssss_check_usdt_pair_loads_lazily_and_caches(monkeypatch):
+    calls = []
+
+    def fake_get(url, timeout):
+        calls.append((url, timeout))
+        return _fake_exchange_info(_FAKE_SYMBOLS)
+
+    monkeypatch.setattr("requests.get", fake_get)
+    module = runpy.run_path(os.path.join(os.path.dirname(__file__), "usdssss"))
+
+    assert calls == []
+    assert module["check_usdt_pair"]("btc long") == "BTCUSDT"
+    assert module["check_usdt_pair"]("eth short") == "ETHUSDT"
+    assert len(calls) == 1
+    assert calls[0][1] == 10
+
+
+def test_usdssss_check_keeps_backwards_compatible_name(monkeypatch):
+    monkeypatch.setattr("requests.get", lambda url, timeout: _fake_exchange_info(_FAKE_SYMBOLS))
+    module = runpy.run_path(os.path.join(os.path.dirname(__file__), "usdssss"))
+
+    assert module["check"]("TRUMP position") == "TRUMPUSDT"
+    assert module["check"]("nothing related") is None

--- a/test_parse_messages.py
+++ b/test_parse_messages.py
@@ -8,7 +8,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(__file__))
-from parse_messages import extract_whale_alert, extract_symbol_block, extract_from_photo, parse_row, main
+from parse_messages import extract_whale_alert, extract_symbol_block, extract_from_photo, parse_row, main, check_usdt_pair
 
 
 WHALE_LONG_TEXT = (
@@ -276,3 +276,44 @@ def test_extract_from_photo_btc_live():
     assert "BTC" in result["symbol"]
     assert result["direction"] == "Long"
     assert result["leverage"] == "100"
+
+
+# --- check_usdt_pair tests ---
+
+_FAKE_SYMBOLS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "TRUMPUSDT", "XRPUSDT"]
+
+
+def test_check_usdt_pair_btc(monkeypatch):
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("BTC is pumping today") == "BTCUSDT"
+
+
+def test_check_usdt_pair_eth(monkeypatch):
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("ETH long 6x") == "ETHUSDT"
+
+
+def test_check_usdt_pair_sol(monkeypatch):
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("SOL LONG 20X entry 85956") == "SOLUSDT"
+
+
+def test_check_usdt_pair_longest_wins(monkeypatch):
+    """When text contains 'TRUMP', TRUMPUSDT should win over any shorter match."""
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("TRUMP position") == "TRUMPUSDT"
+
+
+def test_check_usdt_pair_no_match(monkeypatch):
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("random unrelated text") is None
+
+
+def test_check_usdt_pair_case_insensitive(monkeypatch):
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("btc long") == "BTCUSDT"
+
+
+def test_check_usdt_pair_empty_string(monkeypatch):
+    monkeypatch.setattr("parse_messages._usdt_symbols", _FAKE_SYMBOLS)
+    assert check_usdt_pair("") is None

--- a/usdssss
+++ b/usdssss
@@ -1,16 +1,29 @@
-
 import requests
 
-data = requests.get('https://fapi.binance.com/fapi/v1/exchangeInfo').json()
-symbols = [x["symbol"] for x in data["symbols"] if x['status']=='TRADING']
-symbols = sorted([i.upper() for i in symbols if 'USDT' == i[-4:]])
+BINANCE_EXCHANGE_INFO_URL = 'https://fapi.binance.com/fapi/v1/exchangeInfo'
+_usdt_symbols = None
 
-def check(x):
-    matched = [i for i in symbols if i[:-4] in str(x).upper()]
 
-    if len(matched) == 0:
+def _load_usdt_symbols():
+    global _usdt_symbols
+    if _usdt_symbols is None:
+        try:
+            data = requests.get(BINANCE_EXCHANGE_INFO_URL, timeout=10).json()
+            symbols = [x["symbol"] for x in data["symbols"] if x['status'] == 'TRADING']
+            _usdt_symbols = sorted([i.upper() for i in symbols if i.upper().endswith('USDT')])
+        except Exception:
+            _usdt_symbols = []
+    return _usdt_symbols
+
+
+def check_usdt_pair(text):
+    matched = [i for i in _load_usdt_symbols() if i[:-4] in str(text).upper()]
+
+    if not matched:
         return None
-    else:
-        # Pick the symbol whose base token is longest (most specific match)
-        n_in_b = max(range(len(matched)), key=lambda i: len(matched[i]))
-        return matched[n_in_b]
+
+    return max(matched, key=len)
+
+
+def check(text):
+    return check_usdt_pair(text)

--- a/usdssss
+++ b/usdssss
@@ -1,16 +1,16 @@
 
 import requests
-import tiktoken
 
-data = requests.get('https://fapi.binance.com/fapi/v1/exchangeInfo').json()  
+data = requests.get('https://fapi.binance.com/fapi/v1/exchangeInfo').json()
 symbols = [x["symbol"] for x in data["symbols"] if x['status']=='TRADING']
 symbols = sorted([i.upper() for i in symbols if 'USDT' == i[-4:]])
 
 def check(x):
-    x= [i for i in symbols if i[:-4] in str(x).upper()]
-    
-    if len(x)==0:
+    matched = [i for i in symbols if i[:-4] in str(x).upper()]
+
+    if len(matched) == 0:
         return None
     else:
-        n_in_b = np.argmax([len(i) for i in x])
-        return x[n_in_n]
+        # Pick the symbol whose base token is longest (most specific match)
+        n_in_b = max(range(len(matched)), key=lambda i: len(matched[i]))
+        return matched[n_in_b]


### PR DESCRIPTION
## Summary

Closes #7.

- Refines `usdssss` so the requested file owns a `check_usdt_pair(text)` function that lazily fetches and caches active Binance USDT perpetual symbols, uses a 10 second request timeout, returns the most specific matching pair, and returns `None` when nothing matches.
- Keeps `check(text)` as a backwards-compatible wrapper around `check_usdt_pair(text)`.
- Adds the same USDT pair lookup helper to `parse_messages.py` for parser-side use.
- Adds offline tests for BTC/ETH/SOL lookup, longest-match behavior, no-match, case-insensitivity, empty input, lazy loading/caching in `usdssss`, and the compatibility `check` wrapper.

## How to reproduce the original bug

```python
import runpy
module = runpy.run_path("usdssss")
module["check"]("ETH long 6x")  # original code crashed with NameError: np / n_in_n
```

## Test plan

- [x] `pytest test_parse_messages.py -k usdssss` — 2 passed
- [x] `pytest test_parse_messages.py` — 23 passed, 2 skipped (live API tests skipped without API key)
- [x] `gh run list --repo Georgepop/Telegram_pars --branch issue-7-d4d78977dfab --limit 5 --json databaseId,conclusion,createdAt,headSha` — no GitHub Actions runs configured