### PR TITLE
Fix Binance futures websocket collector

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T11:48:30.534Z for PR creation at branch issue-9-f554205c4fa5 for issue https://github.com/Georgepop/Telegram_pars/issues/9

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T11:48:30.534Z for PR creation at branch issue-9-f554205c4fa5 for issue https://github.com/Georgepop/Telegram_pars/issues/9

--- a/test_websocet.py
+++ b/test_websocet.py
@@ -1,0 +1,145 @@
+"""Tests for the Binance futures websocket collector."""
+
+import json
+from datetime import datetime
+
+import pytest
+
+
+def _closed_kline_event(is_closed=True):
+    return {
+        "e": "kline",
+        "E": 1638747660000,
+        "s": "BTCUSDT",
+        "k": {
+            "t": 1638747660000,
+            "T": 1638747719999,
+            "s": "BTCUSDT",
+            "i": "1m",
+            "o": "0.0010",
+            "c": "0.0020",
+            "h": "0.0025",
+            "l": "0.0015",
+            "v": "1000",
+            "x": is_closed,
+        },
+    }
+
+
+def test_websocet_import_is_side_effect_free():
+    import websocet
+
+    assert websocet.SOCKET_ROUTE == "market"
+
+
+def test_parse_exchange_symbols_filters_trading_usdt_pairs():
+    import websocet
+
+    payload = {
+        "symbols": [
+            {"symbol": "BTCUSDT", "status": "TRADING"},
+            {"symbol": "ETHUSDT", "status": "BREAK"},
+            {"symbol": "ETHBTC", "status": "TRADING"},
+            {"symbol": "SOLUSDT", "status": "TRADING"},
+        ]
+    }
+
+    assert websocet.parse_exchange_symbols(payload) == ["btcusdt", "solusdt"]
+
+
+def test_build_socket_urls_lowercases_and_chunks_streams():
+    import websocet
+
+    urls = websocet.build_socket_urls(
+        ["BTCUSDT", "ETHUSDT"],
+        interval="1m",
+        streams_per_connection=1,
+    )
+
+    assert urls == [
+        "wss://fstream.binance.com/market/stream?streams=btcusdt@kline_1m",
+        "wss://fstream.binance.com/market/stream?streams=ethusdt@kline_1m",
+    ]
+
+
+def test_parse_kline_keeps_existing_output_shape():
+    import websocet
+
+    result = websocet.parse_kline(_closed_kline_event())
+
+    assert result == {
+        "s": "BTCUSDT",
+        "d": 1638747719.999,
+        "h": 0.0025,
+        "l": 0.0015,
+        "t": datetime.fromtimestamp(1638747719.999),
+        "o": 0.001,
+        "c": 0.002,
+        "v": 1000.0,
+        "is_closed": True,
+    }
+
+
+class FakeCollection:
+    def __init__(self):
+        self.inserted = []
+        self.ordered = None
+
+    def insert_many(self, docs, ordered=False):
+        self.inserted.extend(docs)
+        self.ordered = ordered
+
+
+def test_process_market_message_flushes_closed_kline_batches():
+    import websocet
+
+    collection = FakeCollection()
+    buffer = []
+    message = {"data": _closed_kline_event()}
+
+    kline = websocet.process_market_message(
+        json.dumps(message),
+        collection=collection,
+        buffer=buffer,
+        batch_size=1,
+        printer=None,
+    )
+
+    assert kline["s"] == "BTCUSDT"
+    assert collection.inserted == [kline]
+    assert collection.ordered is False
+    assert buffer == []
+
+
+def test_process_market_message_ignores_open_klines():
+    import websocet
+
+    collection = FakeCollection()
+    buffer = []
+    message = {"data": _closed_kline_event(is_closed=False)}
+
+    assert websocet.process_market_message(
+        json.dumps(message),
+        collection=collection,
+        buffer=buffer,
+        batch_size=1,
+        printer=None,
+    ) is None
+    assert collection.inserted == []
+    assert buffer == []
+
+
+def test_build_socket_urls_rejects_empty_symbols():
+    import websocet
+
+    with pytest.raises(ValueError, match="No symbols"):
+        websocet.build_socket_urls([])
+
+
+def test_calculate_reconnect_delay_uses_capped_backoff():
+    import websocet
+
+    assert websocet.calculate_reconnect_delay(0, base_delay=3, max_delay=60) == 3
+    assert websocet.calculate_reconnect_delay(1, base_delay=3, max_delay=60) == 6
+    assert websocet.calculate_reconnect_delay(2, base_delay=3, max_delay=60) == 12
+    assert websocet.calculate_reconnect_delay(10, base_delay=3, max_delay=60) == 60

--- a/websocet.py
+++ b/websocet.py
@@ -1,91 +1,333 @@
+"""Collect closed Binance USD-M futures klines from the websocket API."""
+
 import asyncio
-import websockets
 import json
+import os
+import time
 from datetime import datetime
-import requests
-from typing import *
-from mongopy import *
+from typing import Any, Callable, Iterable, Sequence
+from urllib.request import urlopen
 
 
-data = requests.get('https://fapi.binance.com/fapi/v1/exchangeInfo').json()  
-symbols = [x["symbol"] for x in data["symbols"] if x['status']=='TRADING']
-SYMBOLS = sorted([i.lower() for i in symbols if 'USDT' == i[-4:]])
-
-# ✅ NEW ENDPOINT (required after 2026-04-23)
-SOCKET_URL = "wss://fstream.binance.com/market/stream?streams=" + '/'.join([
-    f'{symbol.lower()}@kline_1m' for symbol in SYMBOLS
-])
-
-insert_buffer: List[dict] = []
-BATCH_SIZE = 1000
+EXCHANGE_INFO_URL = "https://fapi.binance.com/fapi/v1/exchangeInfo"
+WEBSOCKET_BASE_URL = "wss://fstream.binance.com"
+SOCKET_ROUTE = "market"
+STREAM_INTERVAL = os.getenv("BINANCE_KLINE_INTERVAL", "1m")
+BINANCE_MAX_STREAMS_PER_CONNECTION = 1024
 
 
-def flush_buffer(ws=None):
-    global insert_buffer
-    if not insert_buffer: return
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
     try:
-        db['symbols'].insert_many(insert_buffer, ordered=False)
-        insert_buffer.clear()
-    except Exception as e:
-        print(f"[DB Flush Error] {e}")
+        value = int(raw_value)
+    except ValueError:
+        return default
+    return max(value, minimum)
 
 
-def parse_kline(data: dict) -> dict:
-    """Parse kline — ONLY open, close, volume"""
-    k = data['k']
+BATCH_SIZE = _env_int("BATCH_SIZE", 1000)
+FLUSH_INTERVAL_SECONDS = _env_int("FLUSH_INTERVAL_SECONDS", 60)
+RECONNECT_DELAY_SECONDS = _env_int("RECONNECT_DELAY_SECONDS", 3)
+MAX_RECONNECT_DELAY_SECONDS = _env_int("MAX_RECONNECT_DELAY_SECONDS", 300)
+CONNECTION_REFRESH_SECONDS = _env_int("CONNECTION_REFRESH_SECONDS", 23 * 60 * 60)
+MAX_STREAMS_PER_CONNECTION = min(
+    _env_int("MAX_STREAMS_PER_CONNECTION", BINANCE_MAX_STREAMS_PER_CONNECTION),
+    BINANCE_MAX_STREAMS_PER_CONNECTION,
+)
+
+insert_buffer: list[dict[str, Any]] = []
+
+
+def parse_exchange_symbols(exchange_info: dict[str, Any]) -> list[str]:
+    """Return active USD-M USDT symbols in Binance websocket format."""
+    symbols = set()
+    for item in exchange_info.get("symbols", []):
+        symbol = str(item.get("symbol", "")).strip()
+        if item.get("status") == "TRADING" and symbol.endswith("USDT"):
+            symbols.add(symbol.lower())
+    return sorted(symbols)
+
+
+def get_usdt_symbols(
+    exchange_info_url: str = EXCHANGE_INFO_URL,
+    timeout: int = 20,
+) -> list[str]:
+    """Fetch tradable USDT futures symbols from Binance."""
+    with urlopen(exchange_info_url, timeout=timeout) as response:
+        exchange_info = json.loads(response.read().decode("utf-8"))
+    return parse_exchange_symbols(exchange_info)
+
+
+def build_stream_names(symbols: Sequence[str], interval: str = STREAM_INTERVAL) -> list[str]:
+    return [
+        f"{symbol.strip().lower()}@kline_{interval}"
+        for symbol in symbols
+        if symbol and symbol.strip()
+    ]
+
+
+def _chunks(items: Sequence[str], size: int) -> Iterable[list[str]]:
+    if size < 1:
+        raise ValueError("Chunk size must be positive")
+    for start in range(0, len(items), size):
+        yield list(items[start:start + size])
+
+
+def build_socket_url(stream_names: Sequence[str]) -> str:
+    if not stream_names:
+        raise ValueError("No streams were provided")
+    return f"{WEBSOCKET_BASE_URL}/{SOCKET_ROUTE}/stream?streams={'/'.join(stream_names)}"
+
+
+def build_socket_urls(
+    symbols: Sequence[str],
+    interval: str = STREAM_INTERVAL,
+    streams_per_connection: int = MAX_STREAMS_PER_CONNECTION,
+) -> list[str]:
+    stream_names = build_stream_names(symbols, interval=interval)
+    if not stream_names:
+        raise ValueError("No symbols available for websocket subscription")
+
+    streams_per_connection = min(streams_per_connection, BINANCE_MAX_STREAMS_PER_CONNECTION)
+    return [
+        build_socket_url(chunk)
+        for chunk in _chunks(stream_names, streams_per_connection)
+    ]
+
+
+def parse_kline(data: dict[str, Any]) -> dict[str, Any]:
+    """Parse a Binance kline event into the existing storage shape."""
+    kline = data["k"]
+    close_timestamp = kline["T"] / 1000
     return {
-        's': data['s'],
-        'd': k['T']/1000,
-        'h': float(k['h']),
-        'l': float(k['l']),
-        't': datetime.fromtimestamp(k['T'] / 1000),
-        'o': float(k['o']),
-        'c': float(k['c']),
-        'v': float(k['v']),
-        'is_closed': k['x'],
+        "s": data.get("s") or kline.get("s"),
+        "d": close_timestamp,
+        "h": float(kline["h"]),
+        "l": float(kline["l"]),
+        "t": datetime.fromtimestamp(close_timestamp),
+        "o": float(kline["o"]),
+        "c": float(kline["c"]),
+        "v": float(kline["v"]),
+        "is_closed": bool(kline["x"]),
     }
 
-async def futures_kline_stream():
-    global insert_buffer
+
+def flush_buffer(
+    collection: Any | None = None,
+    buffer: list[dict[str, Any]] | None = None,
+) -> int:
+    """Insert buffered klines into MongoDB and clear the buffer after success."""
+    target_buffer = insert_buffer if buffer is None else buffer
+    if not target_buffer or collection is None:
+        return 0
+
+    docs = list(target_buffer)
+    collection.insert_many(docs, ordered=False)
+    target_buffer.clear()
+    return len(docs)
+
+
+def process_kline_event(
+    event: dict[str, Any],
+    collection: Any | None = None,
+    buffer: list[dict[str, Any]] | None = None,
+    batch_size: int = BATCH_SIZE,
+    printer: Callable[[Any], None] | None = print,
+) -> dict[str, Any] | None:
+    if event.get("e") != "kline":
+        return None
+
+    kline = parse_kline(event)
+    if not kline["is_closed"]:
+        return None
+
+    if printer is not None:
+        printer(kline)
+
+    if collection is not None:
+        target_buffer = insert_buffer if buffer is None else buffer
+        target_buffer.append(kline)
+        if len(target_buffer) >= batch_size:
+            flush_buffer(collection, target_buffer)
+
+    return kline
+
+
+def process_market_message(
+    message: str,
+    collection: Any | None = None,
+    buffer: list[dict[str, Any]] | None = None,
+    batch_size: int = BATCH_SIZE,
+    printer: Callable[[Any], None] | None = print,
+) -> dict[str, Any] | None:
+    payload = json.loads(message)
+    event = payload.get("data", payload)
+    if not isinstance(event, dict):
+        return None
+    return process_kline_event(
+        event,
+        collection=collection,
+        buffer=buffer,
+        batch_size=batch_size,
+        printer=printer,
+    )
+
+
+def get_mongo_collection_from_env() -> Any | None:
+    uri = os.getenv("MONGODB_URI") or os.getenv("MONGO_URI")
+    if not uri:
+        return None
+
+    try:
+        from pymongo import MongoClient
+    except ImportError as exc:
+        raise RuntimeError(
+            "pymongo is required when MONGODB_URI or MONGO_URI is configured"
+        ) from exc
+
+    db_name = os.getenv("MONGODB_DB") or os.getenv("MONGODB_DATABASE") or "binance"
+    collection_name = os.getenv("MONGODB_COLLECTION", "symbols")
+    return MongoClient(uri)[db_name][collection_name]
+
+
+def _load_websockets_module() -> Any:
+    try:
+        import websockets
+    except ImportError as exc:
+        raise RuntimeError(
+            "websockets is required to run the Binance stream collector"
+        ) from exc
+    return websockets
+
+
+def _is_invalid_uri_error(websockets_module: Any, exc: Exception) -> bool:
+    invalid_uri = getattr(websockets_module.exceptions, "InvalidURI", None)
+    return invalid_uri is not None and isinstance(exc, invalid_uri)
+
+
+def calculate_reconnect_delay(
+    attempt: int,
+    base_delay: int = RECONNECT_DELAY_SECONDS,
+    max_delay: int = MAX_RECONNECT_DELAY_SECONDS,
+) -> int:
+    return min(max_delay, base_delay * (2 ** max(attempt, 0)))
+
+
+async def consume_socket(
+    socket_url: str,
+    collection: Any | None = None,
+    batch_size: int = BATCH_SIZE,
+    flush_interval_seconds: int = FLUSH_INTERVAL_SECONDS,
+    reconnect_delay_seconds: int = RECONNECT_DELAY_SECONDS,
+    max_reconnect_delay_seconds: int = MAX_RECONNECT_DELAY_SECONDS,
+    connection_refresh_seconds: int = CONNECTION_REFRESH_SECONDS,
+    printer: Callable[[Any], None] | None = print,
+) -> None:
+    websockets = _load_websockets_module()
+    buffer: list[dict[str, Any]] = []
+    reconnect_attempt = 0
+
     while True:
-
         try:
-            print(f"🔌 Connecting to")
-            async with websockets.connect(
-                SOCKET_URL,
-                ping_interval=20,
-                ping_timeout=10
-            ) as ws:
-                
-                async for message in ws:
-                    event = json.loads(message)['data']
-                    if event.get('e') != 'kline':
-                        continue
-                    
-                    kline = parse_kline(event)
-                    if kline['is_closed']:
-                        print(kline)
-                        insert_buffer.append(kline)
-                        
-                        # 4. Batch insert & periodic cleanup
-                        if len(insert_buffer) >= BATCH_SIZE:
-                            flush_buffer(ws)
-                                    # 🔥 Your strategy: on_candle_close(kline)
+            if printer is not None:
+                printer(f"Connecting to {socket_url}")
 
-        except websockets.exceptions.InvalidStatusCode as e:
-            print(f"❌ HTTP Error {e.status_code}: Check endpoint URL")
-            break
-        except websockets.exceptions.InvalidURI as e:
-            print(f"❌ Invalid URI: {e}")
-            break
-        except ConnectionRefusedError:
-            print("❌ Connection refused — check firewall/network")
-        except Exception as e:
-            print(f"⚠️ Error: {type(e).__name__}: {e}")
-        
-        print("🔄 Reconnecting in 3s...")
-        await asyncio.sleep(3)
+            async with websockets.connect(
+                socket_url,
+                ping_interval=None,
+                close_timeout=10,
+            ) as ws:
+                reconnect_attempt = 0
+                connected_at = time.monotonic()
+                last_flush_at = connected_at
+
+                while True:
+                    now = time.monotonic()
+                    if now - connected_at >= connection_refresh_seconds:
+                        if printer is not None:
+                            printer("Refreshing websocket connection before 24h limit")
+                        break
+
+                    message = await ws.recv()
+                    process_market_message(
+                        message,
+                        collection=collection,
+                        buffer=buffer,
+                        batch_size=batch_size,
+                        printer=printer,
+                    )
+
+                    now = time.monotonic()
+                    if collection is not None and now - last_flush_at >= flush_interval_seconds:
+                        inserted = flush_buffer(collection, buffer)
+                        if inserted and printer is not None:
+                            printer(f"Flushed {inserted} klines")
+                        last_flush_at = now
+
+        except asyncio.CancelledError:
+            flush_buffer(collection, buffer)
+            raise
+        except Exception as exc:
+            if _is_invalid_uri_error(websockets, exc):
+                if printer is not None:
+                    printer(f"Invalid websocket URI: {exc}")
+                break
+            if printer is not None:
+                printer(f"Stream error: {type(exc).__name__}: {exc}")
+        finally:
+            try:
+                flush_buffer(collection, buffer)
+            except Exception as exc:
+                if printer is not None:
+                    printer(f"DB flush error: {type(exc).__name__}: {exc}")
+
+        delay = calculate_reconnect_delay(
+            reconnect_attempt,
+            base_delay=reconnect_delay_seconds,
+            max_delay=max_reconnect_delay_seconds,
+        )
+        reconnect_attempt += 1
+        if printer is not None:
+            printer(f"Reconnecting in {delay}s...")
+        await asyncio.sleep(delay)
+
+
+async def futures_kline_stream(
+    symbols: Sequence[str] | None = None,
+    collection: Any | None = None,
+    interval: str = STREAM_INTERVAL,
+    streams_per_connection: int = MAX_STREAMS_PER_CONNECTION,
+    printer: Callable[[Any], None] | None = print,
+) -> None:
+    if symbols is None:
+        symbols = get_usdt_symbols()
+    if collection is None:
+        collection = get_mongo_collection_from_env()
+
+    socket_urls = build_socket_urls(
+        symbols,
+        interval=interval,
+        streams_per_connection=streams_per_connection,
+    )
+
+    if printer is not None:
+        printer(
+            f"Subscribing to {len(symbols)} symbols across "
+            f"{len(socket_urls)} websocket connection(s)"
+        )
+        if collection is None:
+            printer("MONGODB_URI is not set; closed klines will be printed only")
+
+    await asyncio.gather(*[
+        consume_socket(socket_url, collection=collection, printer=printer)
+        for socket_url in socket_urls
+    ])
+
 
 if __name__ == "__main__":
-    print("🚀 Starting Binance Futures Stream (NEW ENDPOINT)...")
-    asyncio.run(futures_kline_stream())
+    try:
+        asyncio.run(futures_kline_stream())
+    except KeyboardInterrupt:
+        print("Stopped")


### PR DESCRIPTION
## Summary
- Refactor `websocet.py` so importing it is side-effect free and does not require websocket, HTTP, or MongoDB packages before runtime.
- Build Binance USD-M Futures `/market/stream?streams=...` URLs from fetched trading USDT symbols, lowercase streams, and cap each connection at Binance's 1024-stream limit.
- Replace the undefined global `db`/`mongopy` usage with optional MongoDB configuration from `MONGODB_URI` or `MONGO_URI`, plus `MONGODB_DB`/`MONGODB_COLLECTION`.
- Make the stream more durable with batched and periodic flushes, capped exponential reconnect backoff, and proactive reconnect before Binance's 24-hour connection limit.

## Reproduction
Before the fix, the new websocket tests failed immediately when importing `websocet.py` because the module imported optional runtime packages and performed network/database setup at import time. The script also referenced an undefined global `db` during flush.

## Verification
- `python -m pytest -q` -> `22 passed, 2 skipped`
- `python -m py_compile websocet.py parse_messages.py test_websocet.py test_parse_messages.py`

## References
- Binance USD-M Futures websocket connection docs: https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Connect
- Binance USD-M Futures kline stream docs: https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Kline-Candlestick-Streams

Fixes Georgepop/Telegram_pars#9
