### PR TITLE
Run websocet.py as a systemd service on Ubuntu

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T12:13:32.727Z for PR creation at branch issue-11-c6757a996d77 for issue https://github.com/Georgepop/Telegram_pars/issues/11

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T12:13:32.727Z for PR creation at branch issue-11-c6757a996d77 for issue https://github.com/Georgepop/Telegram_pars/issues/11

--- a/deploy/INSTALL.md
+++ b/deploy/INSTALL.md
@@ -1,0 +1,112 @@
+# Running `websocet.py` as a systemd service on Ubuntu
+
+This directory contains everything needed to run `websocet.py` as a
+[systemd](https://www.freedesktop.org/wiki/Software/systemd/) service on
+Ubuntu so it starts automatically on boot and restarts on failure.
+
+Files:
+
+- `websocet.service` — systemd unit template (`${SERVICE_USER}` and
+  `${INSTALL_DIR}` are substituted by the installer).
+- `install.sh` — one-shot installer: creates a system user, copies files
+  to `/opt/websocet`, builds a Python virtualenv, installs dependencies,
+  writes the unit file to `/etc/systemd/system/`, then enables and
+  starts the service.
+- `uninstall.sh` — disables and removes the service (keeps files unless
+  `PURGE=1`).
+
+## Quick start
+
+```bash
+git clone https://github.com/Georgepop/Telegram_pars.git
+cd Telegram_pars
+sudo ./deploy/install.sh
+```
+
+That's it — the service is now running and will start on every boot.
+
+## Verify it is running
+
+```bash
+sudo systemctl status websocet
+sudo journalctl -u websocet -f      # follow live logs
+```
+
+## Day‑to‑day commands
+
+```bash
+sudo systemctl restart websocet     # restart
+sudo systemctl stop websocet        # stop
+sudo systemctl start websocet       # start
+sudo systemctl disable websocet     # don't start on boot
+sudo systemctl enable websocet      # start on boot
+```
+
+## Configuration
+
+`install.sh` honours these environment variables:
+
+| Variable        | Default                              | Purpose                              |
+|-----------------|--------------------------------------|--------------------------------------|
+| `INSTALL_DIR`   | `/opt/websocet`                      | Where files and the venv live        |
+| `SERVICE_USER`  | `$SUDO_USER` or `websocet`           | Unix user the service runs as        |
+| `SERVICE_NAME`  | `websocet`                           | Name of the systemd unit             |
+
+Example:
+
+```bash
+sudo INSTALL_DIR=/srv/websocet SERVICE_USER=botuser ./deploy/install.sh
+```
+
+Secrets and runtime configuration (e.g. MongoDB URI) can be placed in
+`/opt/websocet/.env` — the unit loads it via `EnvironmentFile=`. The
+installer creates a placeholder file on first install.
+
+## Manual installation (without `install.sh`)
+
+```bash
+# 1. System packages
+sudo apt-get update
+sudo apt-get install -y python3 python3-venv python3-pip
+
+# 2. Application files + venv
+sudo mkdir -p /opt/websocet
+sudo cp websocet.py requirements.txt /opt/websocet/
+sudo python3 -m venv /opt/websocet/.venv
+sudo /opt/websocet/.venv/bin/pip install -r /opt/websocet/requirements.txt
+
+# 3. Service user (optional — you can also reuse an existing user)
+sudo useradd --system --create-home --shell /usr/sbin/nologin websocet
+sudo chown -R websocet:websocet /opt/websocet
+
+# 4. Install the unit file (substitute placeholders)
+sudo sed \
+  -e 's|${SERVICE_USER}|websocet|g' \
+  -e 's|${INSTALL_DIR}|/opt/websocet|g' \
+  deploy/websocet.service | sudo tee /etc/systemd/system/websocet.service
+
+# 5. Enable and start
+sudo systemctl daemon-reload
+sudo systemctl enable --now websocet
+```
+
+## Uninstall
+
+```bash
+sudo ./deploy/uninstall.sh           # removes the service unit
+sudo PURGE=1 ./deploy/uninstall.sh   # also deletes /opt/websocet
+```
+
+## Troubleshooting
+
+- **Service is `failed`** — inspect logs:
+  `journalctl -u websocet -n 200 --no-pager`.
+- **`ModuleNotFoundError`** — re-run `install.sh`, or:
+  `sudo /opt/websocet/.venv/bin/pip install -r /opt/websocet/requirements.txt`.
+- **`mongopy` import error** — `websocet.py` imports `from mongopy import *`,
+  which is a project-local module. Place `mongopy.py` (or the package)
+  next to `websocet.py` inside `${INSTALL_DIR}` before starting the
+  service.
+- **Port / network errors on first start** — the unit waits for
+  `network-online.target`, but on slow networks you may need to
+  `sudo systemctl restart websocet` once the network is up.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Install websocet.py as a systemd service on Ubuntu so it starts on boot
+# and restarts automatically on failure.
+#
+# Usage:   sudo ./deploy/install.sh
+# Env:     INSTALL_DIR (default /opt/websocet)
+#          SERVICE_USER (default current invoking user, or "websocet" when run via sudo from root)
+#          SERVICE_NAME (default websocet)
+#
+# After install:
+#   sudo systemctl status websocet
+#   journalctl -u websocet -f
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This script must be run as root (use sudo)." >&2
+  exit 1
+fi
+
+REPO_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_DIR="${INSTALL_DIR:-/opt/websocet}"
+SERVICE_NAME="${SERVICE_NAME:-websocet}"
+SERVICE_USER="${SERVICE_USER:-${SUDO_USER:-websocet}}"
+
+echo "==> Repo dir:    ${REPO_DIR}"
+echo "==> Install dir: ${INSTALL_DIR}"
+echo "==> Service:     ${SERVICE_NAME}.service"
+echo "==> Run as user: ${SERVICE_USER}"
+
+# 1. System packages
+echo "==> Installing system packages (python3, venv, pip)..."
+apt-get update -y
+apt-get install -y python3 python3-venv python3-pip
+
+# 2. Service user
+if ! id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+  echo "==> Creating system user '${SERVICE_USER}'..."
+  useradd --system --create-home --shell /usr/sbin/nologin "${SERVICE_USER}"
+fi
+
+# 3. Install files
+echo "==> Copying application files to ${INSTALL_DIR}..."
+mkdir -p "${INSTALL_DIR}"
+install -m 0644 "${REPO_DIR}/websocet.py" "${INSTALL_DIR}/websocet.py"
+if [[ -f "${REPO_DIR}/requirements.txt" ]]; then
+  install -m 0644 "${REPO_DIR}/requirements.txt" "${INSTALL_DIR}/requirements.txt"
+fi
+
+# 4. Python venv + dependencies
+echo "==> Creating virtualenv and installing dependencies..."
+python3 -m venv "${INSTALL_DIR}/.venv"
+"${INSTALL_DIR}/.venv/bin/pip" install --upgrade pip
+if [[ -f "${INSTALL_DIR}/requirements.txt" ]]; then
+  "${INSTALL_DIR}/.venv/bin/pip" install -r "${INSTALL_DIR}/requirements.txt"
+else
+  "${INSTALL_DIR}/.venv/bin/pip" install websockets requests pymongo
+fi
+
+# 5. Optional .env (placeholder if missing)
+if [[ ! -f "${INSTALL_DIR}/.env" ]]; then
+  cat >"${INSTALL_DIR}/.env" <<'ENV'
+# Environment variables for websocet.service.
+# Add MongoDB connection settings or other secrets here, e.g.:
+# MONGO_URI=mongodb://localhost:27017
+ENV
+  chmod 0640 "${INSTALL_DIR}/.env"
+fi
+
+chown -R "${SERVICE_USER}:${SERVICE_USER}" "${INSTALL_DIR}"
+
+# 6. Render and install systemd unit
+UNIT_SRC="${REPO_DIR}/deploy/websocet.service"
+UNIT_DST="/etc/systemd/system/${SERVICE_NAME}.service"
+echo "==> Writing ${UNIT_DST}..."
+sed \
+  -e "s|\${SERVICE_USER}|${SERVICE_USER}|g" \
+  -e "s|\${INSTALL_DIR}|${INSTALL_DIR}|g" \
+  "${UNIT_SRC}" >"${UNIT_DST}"
+chmod 0644 "${UNIT_DST}"
+
+# 7. Enable and start
+echo "==> Reloading systemd and starting service..."
+systemctl daemon-reload
+systemctl enable "${SERVICE_NAME}.service"
+systemctl restart "${SERVICE_NAME}.service"
+
+echo
+echo "==> Done. Useful commands:"
+echo "    sudo systemctl status ${SERVICE_NAME}"
+echo "    sudo journalctl -u ${SERVICE_NAME} -f"
+echo "    sudo systemctl restart ${SERVICE_NAME}"
+echo "    sudo systemctl stop ${SERVICE_NAME}"

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Remove the websocet systemd service installed by deploy/install.sh.
+#
+# Usage: sudo ./deploy/uninstall.sh
+# Env:   INSTALL_DIR (default /opt/websocet)
+#        SERVICE_NAME (default websocet)
+#        PURGE=1 to also delete INSTALL_DIR
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This script must be run as root (use sudo)." >&2
+  exit 1
+fi
+
+INSTALL_DIR="${INSTALL_DIR:-/opt/websocet}"
+SERVICE_NAME="${SERVICE_NAME:-websocet}"
+UNIT_DST="/etc/systemd/system/${SERVICE_NAME}.service"
+
+if systemctl list-unit-files | grep -q "^${SERVICE_NAME}.service"; then
+  systemctl disable --now "${SERVICE_NAME}.service" || true
+fi
+
+rm -f "${UNIT_DST}"
+systemctl daemon-reload
+
+if [[ "${PURGE:-0}" == "1" ]]; then
+  echo "==> Removing ${INSTALL_DIR}..."
+  rm -rf "${INSTALL_DIR}"
+fi
+
+echo "==> Uninstalled ${SERVICE_NAME}.service"

--- a/deploy/websocet.service
+++ b/deploy/websocet.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Binance Futures Kline WebSocket Stream (websocet.py)
+Documentation=https://github.com/Georgepop/Telegram_pars
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${SERVICE_USER}
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${INSTALL_DIR}/.venv/bin/python ${INSTALL_DIR}/websocet.py
+EnvironmentFile=-${INSTALL_DIR}/.env
+Restart=always
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+KillSignal=SIGINT
+TimeoutStopSec=15
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+websockets>=12.0
+requests>=2.31.0
+pymongo>=4.6.0


### PR DESCRIPTION
## Summary

Adds everything needed to run `websocet.py` as a systemd service on
Ubuntu, so the Binance futures kline stream starts automatically on
boot and restarts on failure.

Closes #11

## What's added

- `deploy/websocet.service` — systemd unit template. `Type=simple`,
  `Restart=always`, `After=network-online.target`, optional `.env` via
  `EnvironmentFile=`, basic hardening (`NoNewPrivileges`, `PrivateTmp`,
  `ProtectSystem=full`, `ProtectHome=read-only`).
- `deploy/install.sh` — one‑shot Ubuntu installer:
  installs `python3`/`venv`/`pip`, creates a system user, copies files
  to `/opt/websocet`, builds a virtualenv, installs `requirements.txt`,
  renders the unit into `/etc/systemd/system/`, then `daemon-reload` +
  `enable` + `restart`.
- `deploy/uninstall.sh` — disables and removes the unit
  (`PURGE=1` also wipes `/opt/websocet`).
- `deploy/INSTALL.md` — quick start, verify/manage, manual install
  (no-script) walkthrough, configuration knobs, troubleshooting.
- `requirements.txt` — pins `websockets`, `requests`, `pymongo`.

## Quick start

```bash
git clone https://github.com/Georgepop/Telegram_pars.git
cd Telegram_pars
sudo ./deploy/install.sh
sudo systemctl status websocet
sudo journalctl -u websocet -f
```

Override defaults via env vars:

```bash
sudo INSTALL_DIR=/srv/websocet SERVICE_USER=botuser ./deploy/install.sh
```

## Test plan

- [x] `bash -n deploy/install.sh` and `bash -n deploy/uninstall.sh`
      pass syntax check.
- [x] `sed` substitution on `deploy/websocet.service` produces a valid
      unit (`User=`, `WorkingDirectory=`, `ExecStart=` all rendered).
- [ ] On a fresh Ubuntu host: `sudo ./deploy/install.sh` →
      `systemctl is-active websocet` reports `active`, logs visible via
      `journalctl -u websocet -f`.
- [ ] Reboot test: service comes back up automatically.
- [ ] `sudo ./deploy/uninstall.sh` removes the unit cleanly.

## Notes

`websocet.py` imports `from mongopy import *`. That module isn't in
this repo, so users must drop `mongopy.py` next to `websocet.py` in
`${INSTALL_DIR}` (or add it to the repo) before the service can run
end-to-end. This is called out in `deploy/INSTALL.md` Troubleshooting.